### PR TITLE
Make homebrew/linuxbrew-core the default selected dropdown option

### DIFF
--- a/index.html
+++ b/index.html
@@ -26,9 +26,9 @@ function trigger()
 <form onSubmit="return trigger();">
 <select id="tap" name="tap">
   <option value="brewsci/homebrew-base">Brewsci/base</option>
-  <option value="brewsci/homebrew-bio" selected>Brewsci/bio</option>
+  <option value="brewsci/homebrew-bio">Brewsci/bio</option>
   <option value="brewsci/homebrew-num">Brewsci/num</option>
-  <option value="homebrew/linuxbrew-core">Homebrew/core</option>
+  <option value="homebrew/linuxbrew-core" selected>Homebrew/core</option>
   <option value="linuxbrew/homebrew-extra">Linuxbrew/extra</option>
   <option value="linuxbrew/homebrew-xorg">Linuxbrew/xorg</option>
 </select>

--- a/index.html
+++ b/index.html
@@ -33,7 +33,7 @@ function trigger()
   <option value="linuxbrew/homebrew-xorg">Linuxbrew/xorg</option>
 </select>
 <br>PR <input id="pr" type="number" name="pr">
-<br><input id="keep-old" type="checkbox" name="keep-old" value="1"> Keep-old
+<br><input id="keep-old" type="checkbox" name="keep-old" value="1" checked> Keep-old
 <br><input type="submit" value="Trigger">
 </form>
 <div>


### PR DESCRIPTION
- Most of the bottle builds come from Homebrew/linuxbrew-core, so this
  will save maintainers a couple more clicks whenever bottles haven't
  transferred to BinTray correctly.